### PR TITLE
Enhance templates and update shebangs and actions version

### DIFF
--- a/.devscripts/chmod.sh
+++ b/.devscripts/chmod.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -Eeuo pipefail
 

--- a/.devscripts/migratev1tov2.sh
+++ b/.devscripts/migratev1tov2.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 mkdir -p data/.cache data/StableDiffusion data/Codeformer data/GFPGAN data/ESRGAN data/BSRGAN data/RealESRGAN data/SwinIR data/LDSR data/embeddings
 
 cp -vf cache/models/model.ckpt data/StableDiffusion/model.ckpt

--- a/.devscripts/migratev3tov4.sh
+++ b/.devscripts/migratev3tov4.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -Eeuo pipefail
 

--- a/.devscripts/migratev7tov8.sh
+++ b/.devscripts/migratev7tov8.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -Eeuo pipefail
 
@@ -14,7 +14,6 @@ mv -v ./data/hypernetworks1 ./data/hypernetworks
 
 mv -v ./data/MiDaS ./data/midas1
 mv -v ./data/midas1 ./data/midas
-
 
 echo "Moving folders..."
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,26 @@
-blank_issues_enabled: false
-contact_links:
-  - name: Feature request? Questions regarding some extension?
-    url: https://github.com/AbdBarho/stable-diffusion-webui-docker/discussions
-    about: Please use the discussions tab
+name: Tracking issue
+description: File a bug report.
+title: "[DATE]: [FEATURE NAME]"
+labels: ["bug", "triage"]
+assignees: octocat
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: title
+    attributes:
+      label: Title
+      description: A clear and concise title of what the bug is.
+      placeholder: Bug title
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe the bug
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+# Pull Request Template
+
 <!--
 Have you created an issue before opening a merge request???
 https://github.com/AbdBarho/stable-diffusion-webui-docker#contributing
@@ -6,8 +8,8 @@ Please create one so we can discuss it, I don't want your effort to go to waste.
 
 Closes issue #
 
-### Update versions
+## Update versions
 
-- auto: https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/
-- invoke: https://github.com/invoke-ai/InvokeAI/commit/
-- comfy: https://github.com/comfyanonymous/ComfyUI/commit/
+- auto: <https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/>
+- invoke: <https://github.com/invoke-ai/InvokeAI/commit/>
+- comfy: <https://github.com/comfyanonymous/ComfyUI/commit/>

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,5 +19,5 @@ jobs:
     runs-on: ubuntu-latest
     name: ${{ matrix.profile }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: docker compose --profile ${{ matrix.profile }} build --progress plain


### PR DESCRIPTION
Improve issue and pull request templates for clearer bug reporting and version tracking. Update shebangs to use `/usr/bin/env bash` for better portability and bump the `actions/checkout` version to v4.